### PR TITLE
feat: find gql path from some directory

### DIFF
--- a/src/utils/gql/importGQLModule.js
+++ b/src/utils/gql/importGQLModule.js
@@ -66,3 +66,12 @@ export default async function importGQLModule({
     throw err;
   }
 }
+
+export function exist(path: string): boolean {
+  try {
+    importFrom<GQLModule>(path, GQL_MODULE_NAME);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/gql/index.js
+++ b/src/utils/gql/index.js
@@ -1,6 +1,8 @@
 /* @flow strict */
 import { default as loadGQLService } from './loadGQLService';
 import { type IGQLService, type ILogger } from './types';
+import { exist } from './importGQLModule';
+import { parent } from './nodemodulesPath';
 
 export type { IGQLService, ILogger };
-export { loadGQLService };
+export { loadGQLService, exist as existGQL, parent as parentNodeModulesPath };

--- a/src/utils/gql/nodemodulesPath.js
+++ b/src/utils/gql/nodemodulesPath.js
@@ -1,0 +1,14 @@
+/* @flow strict */
+import paths from 'path';
+
+export function parent(dir: string): ?string {
+  if (paths.basename(dir) === 'node_modules') {
+    return dir;
+  }
+
+  const parent_ = paths.resolve(dir, '..');
+  if (parent_ !== dir) {
+    return parent(parent_);
+  }
+  return null;
+}


### PR DESCRIPTION
Hi.
I'm using this Language Server via [mattn/vim-lsp-settings](https://github.com/mattn/vim-lsp-settings)  installation.
Now need to `$ npm install @playlyfe/gql` in the project root when using it:
https://github.com/mattn/vim-lsp-settings#gql-language-server-graphql

But I want to remove this step.
For that purpose,  I added the same search in node_modules directory as gql-language-server.

This mimics the process of typescript-language-server looking for tsserver:
https://github.com/theia-ide/typescript-language-server/blob/3114c557b58eb6b286e3c63f68ffe56c26800224/server/src/lsp-server.ts#L75

I'm glad if you can merge this pull request.
Thank you.